### PR TITLE
Image version 2.2.104-sdk-stretch

### DIFF
--- a/2.2/sdk/stretch/amd64/Dockerfile
+++ b/2.2/sdk/stretch/amd64/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -SL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-lin
     && echo "$NODE_DOWNLOAD_SHA  nodejs.tar.gz" | sha256sum -c - \
     && tar -xzf "nodejs.tar.gz" -C /usr/local --strip-components=1 \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-    && npm install --global gulp-cli
+    && npm install --global gulp-cli@2.0.1
 
 FROM base AS final
 COPY --from=build /usr/local/bin /usr/local/bin

--- a/2.2/sdk/stretch/amd64/README.md
+++ b/2.2/sdk/stretch/amd64/README.md
@@ -1,0 +1,4 @@
+# Ingredients
+* Based on docker image [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet):2.2.104-sdk-stretch
+* [NodeJS](https://nodejs.org/) LTS 10.15.2
+* [Gulp-cli](https://www.npmjs.com/package/gulp-cli) 2.0.1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Microsoft removed NodeJS from their .NET Core Docker images ([announcement](https://github.com/aspnet/Announcements/issues/298)). This image adds back NodeJS for build time with Gulp pre-installed.
 
+Available on [Docker Hub](https://hub.docker.com/r/mathieu79/dotnet-sdk-nodejs-gulp) - use `docker pull mathieu79/dotnet-sdk-nodejs-gulp` to get it.
+
+
 # Ingredients
 
 * Based on docker images from [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet)


### PR DESCRIPTION
* .NET Core SDK 2.2.104-sdk-stretch
* NodeJS LTS 10.15.2
* Gulp-cli 2.0.1