### PR TITLE
Bump 2.2.401 to 2.2.402

### DIFF
--- a/2.2/sdk/stretch/amd64/Dockerfile-grunt
+++ b/2.2/sdk/stretch/amd64/Dockerfile-grunt
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2.401-stretch AS base
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2.402-stretch AS base
 
 FROM base AS build
-ENV NODE_VERSION 10.16.0
-ENV NODE_DOWNLOAD_SHA 2e2cddf805112bd0b5769290bf2d1bc4bdd55ee44327e826fa94c459835a9d9a
+ENV NODE_VERSION 10.16.3
+ENV NODE_DOWNLOAD_SHA 2f0397bb81c1d0c9901b9aff82a933257bf60f3992227b86107111a75b9030d9
 RUN curl -SL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" --output nodejs.tar.gz \
     && echo "$NODE_DOWNLOAD_SHA  nodejs.tar.gz" | sha256sum -c - \
     && tar -xzf "nodejs.tar.gz" -C /usr/local --strip-components=1 \

--- a/2.2/sdk/stretch/amd64/Dockerfile-gulp
+++ b/2.2/sdk/stretch/amd64/Dockerfile-gulp
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2.401-stretch AS base
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2.402-stretch AS base
 
 FROM base AS build
-ENV NODE_VERSION 10.16.0
-ENV NODE_DOWNLOAD_SHA 2e2cddf805112bd0b5769290bf2d1bc4bdd55ee44327e826fa94c459835a9d9a
+ENV NODE_VERSION 10.16.3
+ENV NODE_DOWNLOAD_SHA 2f0397bb81c1d0c9901b9aff82a933257bf60f3992227b86107111a75b9030d9
 RUN curl -SL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" --output nodejs.tar.gz \
     && echo "$NODE_DOWNLOAD_SHA  nodejs.tar.gz" | sha256sum -c - \
     && tar -xzf "nodejs.tar.gz" -C /usr/local --strip-components=1 \

--- a/2.2/sdk/stretch/amd64/README.md
+++ b/2.2/sdk/stretch/amd64/README.md
@@ -1,5 +1,5 @@
 # Ingredients
-* Based on docker image [mcr.microsoft.com/dotnet/core/sdk](https://hub.docker.com/_/microsoft-dotnet-core-sdk/):2.2.401-stretch
-* [NodeJS](https://nodejs.org/) LTS 10.16.0
+* Based on docker image [mcr.microsoft.com/dotnet/core/sdk](https://hub.docker.com/_/microsoft-dotnet-core-sdk/):2.2.402-stretch
+* [NodeJS](https://nodejs.org/) LTS 10.16.3
 * [Gulp-cli](https://www.npmjs.com/package/gulp-cli) 2.2.0
 * [Grunt-cli](https://www.npmjs.com/package/grunt-cli) 1.3.2


### PR DESCRIPTION
- Core SDK updated to 2.2.402
- NodeJS updated to 10.16.3