### PR TITLE
Upgrades 5.0.202 -> 5.0.300

### DIFF
--- a/5.0/sdk/alpine/webpack/Dockerfile
+++ b/5.0/sdk/alpine/webpack/Dockerfile
@@ -1,13 +1,13 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.202-alpine3.13 AS base
+FROM mcr.microsoft.com/dotnet/sdk:5.0.300-alpine3.13 AS base
 
 FROM base AS build
-ENV NODE_VERSION 14.16.1
-ENV NODE_DOWNLOAD_SHA 3ab0de3b6eb975acc1ef6eabc5edc8a8ae034444c0efb3762af450ca72732374
+ENV NODE_VERSION 14.17.0
+ENV NODE_DOWNLOAD_SHA 7a2c5a69ca44ac1bf7e7fa7ec578e9da82f9187aa5cd8d551a877aeb57985e27
 RUN curl -SL "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.gz" --output nodejs.tar.gz \
     && echo "$NODE_DOWNLOAD_SHA  nodejs.tar.gz" | sha256sum -c - \
     && tar -xzf "nodejs.tar.gz" -C /usr/local --strip-components=1 --no-same-owner \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-    && npm install --global webpack@5.34.0 webpack-cli@4.6.0
+    && npm install --global webpack@5.37.1 webpack-cli@4.7.0
 
 FROM base AS final
 COPY --from=build /usr/local/bin /usr/local/bin

--- a/5.0/sdk/alpine/webpack/README.md
+++ b/5.0/sdk/alpine/webpack/README.md
@@ -2,12 +2,12 @@
 Microsoft removed NodeJS from their .NET Core Docker images ([announcement](https://github.com/aspnet/Announcements/issues/298)). This image adds back NodeJS for build time with Webpack pre-installed.
 
 # Ingredients
-* Based on docker image [mcr.microsoft.com/dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/):5.0.202-alpine3.13
-* [NodeJS](https://nodejs.org/) LTS 14.16.1
-* [Webpack](https://www.npmjs.com/package/webpack) 5.34.0
-* [Webpack-cli](https://www.npmjs.com/package/webpack-cli) 4.6.0
+* Based on docker image [mcr.microsoft.com/dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/):5.0.300-alpine3.13
+* [NodeJS](https://nodejs.org/) LTS 14.17.0
+* [Webpack](https://www.npmjs.com/package/webpack) 5.37.1
+* [Webpack-cli](https://www.npmjs.com/package/webpack-cli) 4.7.0
 
 # Full Tag Listing
 ## Linux amd64 tags
-- [`5.0.202-buster-slim`, `5.0-sdk`, `latest` (*Dockerfile*)](https://github.com/Mathieu79FI/dotnet-docker/blob/master/5.0/sdk/buster-slim/webpack/Dockerfile)
-- [`5.0.202-alpine`, `5.0-sdk-alpine` (*Dockerfile*)](https://github.com/Mathieu79FI/dotnet-docker/blob/master/5.0/sdk/alpine/webpack/Dockerfile)
+- [`5.0.300-buster-slim`, `5.0-sdk`, `latest` (*Dockerfile*)](https://github.com/Mathieu79FI/dotnet-docker/blob/master/5.0/sdk/buster-slim/webpack/Dockerfile)
+- [`5.0.300-alpine`, `5.0-sdk-alpine` (*Dockerfile*)](https://github.com/Mathieu79FI/dotnet-docker/blob/master/5.0/sdk/alpine/webpack/Dockerfile)

--- a/5.0/sdk/buster-slim/webpack/Dockerfile
+++ b/5.0/sdk/buster-slim/webpack/Dockerfile
@@ -1,13 +1,13 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.202-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/sdk:5.0.300-buster-slim AS base
 
 FROM base AS build
-ENV NODE_VERSION 14.16.1
-ENV NODE_DOWNLOAD_SHA 068400cb9f53d195444b9260fd106f7be83af62bb187932656b68166a2f87f44
+ENV NODE_VERSION 14.17.0
+ENV NODE_DOWNLOAD_SHA 3d06eabc73ec8626337bff370474306eac1c3c21122f677720d154c556ceafaf
 RUN curl -SL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" --output nodejs.tar.gz \
     && echo "$NODE_DOWNLOAD_SHA  nodejs.tar.gz" | sha256sum -c - \
     && tar -xzf "nodejs.tar.gz" -C /usr/local --strip-components=1 \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-    && npm install --global webpack@5.34.0 webpack-cli@4.6.0
+    && npm install --global webpack@5.37.1 webpack-cli@4.7.0
 
 FROM base AS final
 COPY --from=build /usr/local/bin /usr/local/bin

--- a/5.0/sdk/buster-slim/webpack/README.md
+++ b/5.0/sdk/buster-slim/webpack/README.md
@@ -2,12 +2,12 @@
 Microsoft removed NodeJS from their .NET Core Docker images ([announcement](https://github.com/aspnet/Announcements/issues/298)). This image adds back NodeJS for build time with Webpack pre-installed.
 
 # Ingredients
-* Based on docker image [mcr.microsoft.com/dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/):5.0.202-buster-slim
-* [NodeJS](https://nodejs.org/) LTS 14.16.1
-* [Webpack](https://www.npmjs.com/package/webpack) 5.34.0
-* [Webpack-cli](https://www.npmjs.com/package/webpack-cli) 4.6.0
+* Based on docker image [mcr.microsoft.com/dotnet/sdk](https://hub.docker.com/_/microsoft-dotnet-sdk/):5.0.300-buster-slim
+* [NodeJS](https://nodejs.org/) LTS 14.17.0
+* [Webpack](https://www.npmjs.com/package/webpack) 5.37.1
+* [Webpack-cli](https://www.npmjs.com/package/webpack-cli) 4.7.0
 
 # Full Tag Listing
 ## Linux amd64 tags
-- [`5.0.202-buster-slim`, `5.0-sdk`, `latest` (*Dockerfile*)](https://github.com/Mathieu79FI/dotnet-docker/blob/master/5.0/sdk/buster-slim/webpack/Dockerfile)
-- [`5.0.202-alpine`, `5.0-sdk-alpine` (*Dockerfile*)](https://github.com/Mathieu79FI/dotnet-docker/blob/master/5.0/sdk/alpine/webpack/Dockerfile)
+- [`5.0.300-buster-slim`, `5.0-sdk`, `latest` (*Dockerfile*)](https://github.com/Mathieu79FI/dotnet-docker/blob/master/5.0/sdk/buster-slim/webpack/Dockerfile)
+- [`5.0.300-alpine`, `5.0-sdk-alpine` (*Dockerfile*)](https://github.com/Mathieu79FI/dotnet-docker/blob/master/5.0/sdk/alpine/webpack/Dockerfile)


### PR DESCRIPTION
Bumps dotnet/core/sdk from 5.0.202-buster-slim to 5.0.300-buster-slim.
Bumps dotnet/core/sdk from 5.0.202-alpine3.13 to 5.0.300-alpine3.13.
Bumps NodeJS from 14.16.1 to 14.17.0.
Bumps Webpack from 5.34.0 to 5.37.1.
Bumps Webpack-cli from 4.6.0 to 4.7.0.